### PR TITLE
Bug 1870195: round provisioned size up to 1MiB

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -15,6 +15,7 @@ import (
 const (
 	ParameterStorageDomainName = "storageDomainName"
 	ParameterThinProvisioning  = "thinProvisioning"
+	minimumDiskSize            = 1 * 1024 * 1024
 )
 
 //ControllerService implements the controller interface
@@ -54,11 +55,16 @@ func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// TODO rgolan the default in case of error would be non thin - change it?
 	thinProvisioning, _ := strconv.ParseBool(req.Parameters[ParameterThinProvisioning])
 
+	provisionedSize := req.CapacityRange.GetRequiredBytes()
+	if provisionedSize < minimumDiskSize {
+		provisionedSize = minimumDiskSize
+	}
+
 	// creating the disk
 	disk, err := ovirtsdk.NewDiskBuilder().
 		Name(req.Name).
 		StorageDomainsBuilderOfAny(*ovirtsdk.NewStorageDomainBuilder().Name(req.Parameters[ParameterStorageDomainName])).
-		ProvisionedSize(req.CapacityRange.GetRequiredBytes()).
+		ProvisionedSize(provisionedSize).
 		ReadOnly(false).
 		Format(ovirtsdk.DISKFORMAT_COW).
 		Sparse(thinProvisioning).


### PR DESCRIPTION
It is possible to pass "1" instead of 1Mi in PVC, for example:
```yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: 1m-ovirt-cow-disk
  annotations:
    volume.beta.kubernetes.io/storage-class: ovirt-csi-sc
spec:
  storageClassName: ovirt-csi-sc
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1
```
This will be interperted as 1Mi when running `oc describe`
```shell
$ oc describe pvc/1m-ovirt-cow-disk
Name:          1m-ovirt-cow-disk
Namespace:     default
StorageClass:  ovirt-csi-sc
...
Capacity:      1Mi
```

However, "1" will be return by `CapacityRange#GetRequiredBytes`[1], which would later fail `mkfs.ext4` because it will not have enough space to create the filesystem.

This PR will round the size up to a minimum of 1MiB



[1] https://github.com/openshift/ovirt-csi-driver/blob/6b3a1d8c2d787c51ca13cbfdbfc07c8db3112a1c/pkg/service/controller.go#L69



Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>