### PR TITLE
Bug 1882383: Support XFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN make build
 
 FROM fedora:31
 
-RUN dnf install -y e2fsprogs
+RUN dnf install -y e2fsprogs xfsprogs
 COPY --from=builder /src/ovirt-csi-driver/bin/ovirt-csi-driver .
 
 ENTRYPOINT ["./ovirt-csi-driver"]


### PR DESCRIPTION
- Add `xfsprogs` to the driver's image
- use `-f` flag when `mkfs`ing XFS