### PR TITLE
Updating ose-ovirt-csi-driver builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /src/ovirt-csi-driver
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 RUN yum install -y e2fsprogs xfsprogs
 COPY --from=builder /src/ovirt-csi-driver/bin/ovirt-csi-driver .


### PR DESCRIPTION
Updating ose-ovirt-csi-driver builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-ovirt-csi-driver.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.