### PR TITLE
disable metrics

### DIFF
--- a/cmd/ovirt-csi-driver/ovirt-csi-driver.go
+++ b/cmd/ovirt-csi-driver/ovirt-csi-driver.go
@@ -53,7 +53,8 @@ func handle() {
 	}
 
 	opts := manager.Options{
-		Namespace: *namespace,
+		Namespace:          *namespace,
+		MetricsBindAddress: "0",
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components


### PR DESCRIPTION
We don't really expose any metrics so its usefulness is doubtful. This also causes collisions with other services using the 8080 port.