### PR TITLE
make NodePublishVolume idempotent

### DIFF
--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -93,7 +93,7 @@ func (n *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	targetPath := req.GetTargetPath()
 	err = os.MkdirAll(targetPath, 0750)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return nil, errors.New(err.Error())
 	}
 


### PR DESCRIPTION
NodePublishVolume must be an idempotent operation according to the spec[1], so we cannot fail if the path already exists, as it will fail when executed twice.

[1] https://github.com/container-storage-interface/spec/blob/master/spec.md#nodepublishvolume