### PR TITLE
Abstract all NodeService tools call

### DIFF
--- a/pkg/service/driver.go
+++ b/pkg/service/driver.go
@@ -26,7 +26,7 @@ func NewOvirtCSIDriver(ovirtClient *ovirt.Client, client client.Client, nodeId s
 	d := OvirtCSIDriver{
 		IdentityService:   &IdentityService{},
 		ControllerService: &ControllerService{ovirtClient: ovirtClient, client: client},
-		NodeService:       &NodeService{nodeId: nodeId, ovirtClient: ovirtClient},
+		NodeService:       NewNodeService(nodeId, ovirtClient),
 		ovirtClient:       ovirtClient,
 		Client:            client,
 	}


### PR DESCRIPTION
This commit replaces every concrete call of system operations (like mkdir
mkfs, mount) with interfaces. This will allow easy development of
unit-tests.

Signed-off-by: Roy Golan <rgolan@redhat.com>
