### PR TITLE
Bug 1918287: pass ovirtClient to identity and remove redundant call to Test connection

### DIFF
--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -49,7 +49,6 @@ func (o *Client) GetConnection() (*ovirtsdk.Connection, error) {
 	if o.connection == nil || o.connection.Test() != nil {
 		return newOvirtConnection()
 	}
-
 	return o.connection, nil
 }
 

--- a/pkg/service/driver.go
+++ b/pkg/service/driver.go
@@ -24,7 +24,7 @@ type OvirtCSIDriver struct {
 // NewOvirtCSIDriver creates a driver instance
 func NewOvirtCSIDriver(ovirtClient *ovirt.Client, client client.Client, nodeId string) *OvirtCSIDriver {
 	d := OvirtCSIDriver{
-		IdentityService:   &IdentityService{},
+		IdentityService:   &IdentityService{ovirtClient},
 		ControllerService: &ControllerService{ovirtClient: ovirtClient, client: client},
 		NodeService:       &NodeService{nodeId: nodeId, ovirtClient: ovirtClient},
 		ovirtClient:       ovirtClient,

--- a/pkg/service/identity.go
+++ b/pkg/service/identity.go
@@ -12,7 +12,7 @@ import (
 
 //IdentityService of ovirt-csi-driver
 type IdentityService struct {
-	ovirtClient ovirt.Client
+	ovirtClient *ovirt.Client
 }
 
 //GetPluginInfo returns the vendor name and version - set in build time
@@ -39,17 +39,11 @@ func (i *IdentityService) GetPluginCapabilities(context.Context, *csi.GetPluginC
 }
 
 // Probe checks the state of the connection to ovirt-engine
-func (i *IdentityService) Probe(ctx context.Context, request *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	c, err := i.ovirtClient.GetConnection()
+func (i *IdentityService) Probe(_ context.Context, _ *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+	_, err := i.ovirtClient.GetConnection()
 	if err != nil {
 		klog.Errorf("Could not get connection %v", err)
 		return nil, status.Error(codes.FailedPrecondition, "Could not get connection to ovirt-engine")
 	}
-
-	if err := c.Test(); err != nil {
-		klog.Errorf("Connection test failed %v", err)
-		return nil, status.Error(codes.FailedPrecondition, "Could not get connection to ovirt-engine")
-	}
-
 	return &csi.ProbeResponse{Ready: &wrappers.BoolValue{Value: true}}, nil
 }


### PR DESCRIPTION
We didn't pass the ovirtClient to the identity on creation which caused a new connection to be created on each call to ovirtClient.GetConnection().
On top of that we called the Test function which is redundant since it is either a new connection or it is being called in the function.

Those 2 errors caused the logs to get filled with auth requests and the evnet tab in the engine to get filled with auth events.