### PR TITLE
WIP: Bug 1969960: CSI driver ignores CA bundle

### DIFF
--- a/internal/ovirt/ovirt.go
+++ b/internal/ovirt/ovirt.go
@@ -32,6 +32,7 @@ func newOvirtConnection() (*ovirtsdk.Connection, error) {
 		Username(ovirtConfig.Username).
 		Password(ovirtConfig.Password).
 		CAFile(ovirtConfig.CAFile).
+		CACert(ovirtConfig.CABundle).
 		Insecure(ovirtConfig.Insecure).
 		Build()
 	if err != nil {
@@ -64,6 +65,7 @@ type Config struct {
 	Username string `yaml:"ovirt_username"`
 	Password string `yaml:"ovirt_password"`
 	CAFile   string `yaml:"ovirt_cafile,omitempty"`
+	CABundle []byte `yaml:"ovirt_ca_bundle,omitempty"`
 	Insecure bool   `yaml:"ovirt_insecure,omitempty"`
 }
 


### PR DESCRIPTION
This PR hopefully fixes [BZ 1969960](https://bugzilla.redhat.com/show_bug.cgi?id=1969960) where the `ovirt_ca_bundle` field is ignored in the credentials secret.

This PR is untested.