### PR TITLE
fix s390x build bug

### DIFF
--- a/pkg/utils/volumemanager.go
+++ b/pkg/utils/volumemanager.go
@@ -18,13 +18,13 @@ func StatFS(path string) (available, capacity, used, inodesFree, inodes, inodesU
 	}
 
 	// Available is blocks available * fragment size
-	available = int64(statfs.Bavail) * statfs.Bsize
+	available = int64(statfs.Bavail) * int64(statfs.Bsize)
 
 	// Capacity is total block count * fragment size
-	capacity = int64(statfs.Blocks) * statfs.Bsize
+	capacity = int64(statfs.Blocks) * int64(statfs.Bsize)
 
 	// Usage is block being used * fragment size (aka block size).
-	used = (int64(statfs.Blocks) - int64(statfs.Bfree)) * statfs.Bsize
+	used = (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize)
 
 	// Get inode usage
 	inodes = int64(statfs.Files)


### PR DESCRIPTION
On s390x we get "pkg/utils/volumemanager.go:21:35: invalid operation: int64(statfs.Bavail) * statfs.Bsize (mismatched types int64 and uint32)" error, now we verify it is always int64