### PR TITLE
Bug 1882983: check PV access mode

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -51,6 +51,13 @@ func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 			"failed to parse storage class field %s, expected 'true' or 'false' but got %s",
 			ParameterThinProvisioning, req.Parameters[ParameterThinProvisioning])
 	}
+	// Check access mode
+	for _, cap := range req.GetVolumeCapabilities() {
+		if cap.AccessMode.Mode != csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY &&
+			cap.AccessMode.Mode != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+			return nil, fmt.Errorf("unsupported access mode %s, currently only RWO is supported", cap.AccessMode.Mode)
+		}
+	}
 	requiredSize := req.CapacityRange.GetRequiredBytes()
 	// Check if a disk with the same name already exist
 	disks, err := c.ovirtClient.ListDisksByAlias(diskName, ovirtclient.ContextStrategy(ctx))


### PR DESCRIPTION
Currently we support attaching volumes only to the single node and
therefore ROX and RWX modes are not possible. Check access mode before
creating PV and fail PV creation if user requests multi node access.