### PR TITLE
improved logging if no storage domain is found by name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/ovirt/go-ovirt-client-log-klog/v2 v2.0.0
 	github.com/ovirt/go-ovirt-client-log/v3 v3.0.0
-	github.com/ovirt/go-ovirt-client/v2 v2.0.0
+	github.com/ovirt/go-ovirt-client/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1 // indirect
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,8 @@ github.com/ovirt/go-ovirt-client-log-klog/v2 v2.0.0 h1:lQJGJ1VIDMgFiU4J5yXo9npvC
 github.com/ovirt/go-ovirt-client-log-klog/v2 v2.0.0/go.mod h1:Bo83WSGfqYsatXlrOnG0jp8fvrmf5xGzJnpJqVsS+1s=
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0 h1:uvACVHYhYPMkNJrrgWiABcfELB6qoFfsDDUTbpb4Jv4=
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0/go.mod h1:chKKxCv4lRjxezrTG+EIhkWXGhDAWByglPVXh/iYdnQ=
-github.com/ovirt/go-ovirt-client/v2 v2.0.0 h1:Woewddu0kX7y1VG+h/O4rLWKBqxjSvui3Op+SBEoeuU=
-github.com/ovirt/go-ovirt-client/v2 v2.0.0/go.mod h1:Zi2RF2khEr+hcr3fCAf6WL7OEoUwUHeWWiob/WcEaDc=
+github.com/ovirt/go-ovirt-client/v2 v2.0.1 h1:Avznl0vB5kCeOf1Wxg/kWjZ7cr2sIc4sGKwD4T+/C9o=
+github.com/ovirt/go-ovirt-client/v2 v2.0.1/go.mod h1:Zi2RF2khEr+hcr3fCAf6WL7OEoUwUHeWWiob/WcEaDc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -18,7 +18,7 @@ const (
 	minimumDiskSize            = 1 * 1024 * 1024
 )
 
-//ControllerService implements the controller interface
+// ControllerService implements the controller interface
 type ControllerService struct {
 	ovirtClient ovirtclient.Client
 }
@@ -29,7 +29,7 @@ var ControllerCaps = []csi.ControllerServiceCapability_RPC_Type{
 	csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 }
 
-//CreateVolume creates the disk for the request, unattached from any VM
+// CreateVolume creates the disk for the request, unattached from any VM
 func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	klog.Infof("Creating disk %s", req.Name)
 	storageDomainName := req.Parameters[ParameterStorageDomainName]
@@ -115,9 +115,6 @@ func (c *ControllerService) createDisk(
 	if err != nil {
 		return nil, fmt.Errorf("failed searching for storage domain with name %s, error: %w", storageDomainName, err)
 	}
-	if sd == nil {
-		return nil, fmt.Errorf("failed searching for storage domain with name %s, error: %w", storageDomainName, err)
-	}
 	imageFormat := handleCreateVolumeImageFormat(sd.StorageType(), thinProvisioning)
 
 	disk, err := c.ovirtClient.CreateDisk(
@@ -146,7 +143,7 @@ func handleCreateVolumeImageFormat(
 	}
 }
 
-//DeleteVolume removed the disk from oVirt
+// DeleteVolume removed the disk from oVirt
 func (c *ControllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	vId := ovirtclient.DiskID(req.VolumeId)
 	if len(vId) == 0 {
@@ -223,7 +220,7 @@ func (c *ControllerService) ControllerPublishVolume(
 	return &csi.ControllerPublishVolumeResponse{}, nil
 }
 
-//ControllerUnpublishVolume detaches the disk from the VM.
+// ControllerUnpublishVolume detaches the disk from the VM.
 func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	vId := ovirtclient.DiskID(req.VolumeId)
 	if len(vId) == 0 {
@@ -253,37 +250,37 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
-//ValidateVolumeCapabilities
+// ValidateVolumeCapabilities
 func (c *ControllerService) ValidateVolumeCapabilities(context.Context, *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-//ListVolumes
+// ListVolumes
 func (c *ControllerService) ListVolumes(context.Context, *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-//GetCapacity
+// GetCapacity
 func (c *ControllerService) GetCapacity(context.Context, *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-//CreateSnapshot
+// CreateSnapshot
 func (c *ControllerService) CreateSnapshot(context.Context, *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-//DeleteSnapshot
+// DeleteSnapshot
 func (c *ControllerService) DeleteSnapshot(context.Context, *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-//ListSnapshots
+// ListSnapshots
 func (c *ControllerService) ListSnapshots(context.Context, *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-//ControllerExpandVolume
+// ControllerExpandVolume
 func (c *ControllerService) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	volumeID := ovirtclient.DiskID(req.GetVolumeId())
 	if len(volumeID) == 0 {
@@ -360,7 +357,7 @@ func (c *ControllerService) isNodeExpansionRequired(
 	return true, nil
 }
 
-//ControllerGetCapabilities
+// ControllerGetCapabilities
 func (c *ControllerService) ControllerGetCapabilities(context.Context, *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 	caps := make([]*csi.ControllerServiceCapability, 0, len(ControllerCaps))
 	for _, capability := range ControllerCaps {

--- a/pkg/service/helper.go
+++ b/pkg/service/helper.go
@@ -86,7 +86,7 @@ func getStorageDomainByName(
 			return sd, nil
 		}
 	}
-	return nil, nil
+	return nil, errors.New("No storage domain found")
 }
 
 func isFileDomain(storageType ovirtclient.StorageDomainType) bool {

--- a/vendor/github.com/ovirt/go-ovirt-client/v2/errors.go
+++ b/vendor/github.com/ovirt/go-ovirt-client/v2/errors.go
@@ -15,6 +15,9 @@ type ErrorCode string
 // EAccessDenied signals that the provided credentials for the oVirt engine were incorrect.
 const EAccessDenied ErrorCode = "access_denied"
 
+// EUserAccountLocked signals that the provided user account for the oVirt engine has been locked.
+const EUserAccountLocked ErrorCode = "user_locked"
+
 // ENotAnOVirtEngine signals that the server did not respond with a proper oVirt response.
 const ENotAnOVirtEngine ErrorCode = "not_ovirt_engine"
 
@@ -112,6 +115,8 @@ func (e ErrorCode) CanAutoRetry() bool {
 		return false
 	case EAccessDenied:
 		return false
+	case EUserAccountLocked:
+		return false
 	case ENotAnOVirtEngine:
 		return false
 	case ETLSError:
@@ -141,14 +146,14 @@ func (e ErrorCode) CanAutoRetry() bool {
 //
 // Usage:
 //
-//   if err != nil {
-//     var realErr ovirtclient.EngineError
-//     if errors.As(err, &realErr) {
-//          // deal with EngineError
-//     } else {
-//          // deal with other errors
-//     }
-//   }
+//	if err != nil {
+//	  var realErr ovirtclient.EngineError
+//	  if errors.As(err, &realErr) {
+//	       // deal with EngineError
+//	  } else {
+//	       // deal with other errors
+//	  }
+//	}
 type EngineError interface {
 	error
 
@@ -261,6 +266,7 @@ func wrap(err error, code ErrorCode, format string, args ...interface{}) EngineE
 	}
 }
 
+//nolint:funlen
 func realIdentify(err error) EngineError {
 	var authErr *ovirtsdk.AuthError
 	var notFoundErr *ovirtsdk.NotFoundError
@@ -318,7 +324,11 @@ func realIdentify(err error) EngineError {
 	case errors.As(err, &authErr):
 		fallthrough
 	case strings.Contains(err.Error(), "access_denied"):
-		return wrap(err, EAccessDenied, "access denied, check your credentials")
+		wrappedErr := wrap(err, EAccessDenied, "access denied, check your credentials")
+		if strings.Contains(err.Error(), "user account is disabled or locked") {
+			wrappedErr = wrap(wrappedErr, EUserAccountLocked, "access denied, user account has been locked")
+		}
+		return wrappedErr
 	default:
 		return nil
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -67,7 +67,7 @@ github.com/ovirt/go-ovirt-client-log-klog/v2
 # github.com/ovirt/go-ovirt-client-log/v3 v3.0.0
 ## explicit
 github.com/ovirt/go-ovirt-client-log/v3
-# github.com/ovirt/go-ovirt-client/v2 v2.0.0
+# github.com/ovirt/go-ovirt-client/v2 v2.0.1
 ## explicit
 github.com/ovirt/go-ovirt-client/v2
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
This PR improves the logging if no storage domain is found by name. ([OCPRHV-695](https://issues.redhat.com/browse/OCPRHV-695))

Currently, logs for this case look like this:
```bash
failed searching for storage domain with name iscsi_*, error: %!!(MISSING)w(<nil>)  
```
This PR changes this message to be more explicit:
```bash
failed searching for storage domain with name iscsi_*, error: No storage domain found
```